### PR TITLE
metadata changes

### DIFF
--- a/cli/cmd/init.go
+++ b/cli/cmd/init.go
@@ -4,10 +4,8 @@ Copyright © 2024 Arek Ouzounian <arek@arekouzounian.com>
 package cmd
 
 import (
-	"encoding/json"
 	"fmt"
 	"os"
-	"time"
 
 	"github.com/spf13/cobra"
 )
@@ -56,19 +54,9 @@ The assets folder is where you can place anything you may be referencing in the 
 		// directory exists at <output>/ now.
 		output += "/"
 
-		meta := BlogPostMetaData{
-			CreatedAt:   time.Now(),
-			LastChanged: time.Now(),
-		}
-		json, err := json.Marshal(meta)
+		err = WriteMetaDataFromInput(output)
 		if err != nil {
-			fmt.Println("Fatal: ", err.Error())
-			return
-		}
-		err = os.WriteFile(output+"meta.json", json, os.FileMode(0666))
-		if err != nil {
-			fmt.Println("Error creating meta.json")
-			fmt.Println(err.Error())
+			fmt.Printf("Error creating meta.json: %v", err)
 			return
 		}
 
@@ -95,14 +83,5 @@ This is a file template. Feel free to get rid of this and replace it with your o
 func init() {
 	postCmd.AddCommand(initCmd)
 
-	// Here you will define your flags and configuration settings.
-
-	// Cobra supports Persistent Flags which will work for this command
-	// and all subcommands, e.g.:
-	// initCmd.PersistentFlags().String("foo", "", "A help for foo")
-
-	// Cobra supports local flags which will only run when this command
-	// is called directly, e.g.:
-	// initCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
 	initCmd.Flags().StringP("output", "o", ".", "specifies the directory that the new subdirectory will be located within.")
 }

--- a/cli/cmd/types.go
+++ b/cli/cmd/types.go
@@ -4,10 +4,6 @@ package cmd
 Copyright © 2024 Arek Ouzounian <arek@arekouzounian.com>
 */
 
-import (
-	"time"
-)
-
 // stores absolute paths of valid post directory elements
 type ValidateDirectoryStructureResult struct {
 	MarkdownFilePath string
@@ -16,10 +12,13 @@ type ValidateDirectoryStructureResult struct {
 }
 
 type BlogPostMetaData struct {
-	CreatedAt   time.Time
-	LastChanged time.Time
+	LastChanged int64
 
-	// author, title, tags, thumbnail/image?
+	Author      string
+	Title       string
+	Description string
+
+	// tags, thumbnail/img?
 }
 
 type CheckList[K comparable] struct {


### PR DESCRIPTION
This commit is made to address #3

Here are the new changes: 
- `meta.json` now holds these fields: 
  - `LastChanged`, which is a UNIX timestamp regarding the time when the document was last changed
  - `Author`, which is the author field 
  - `Title`, which is the title of the post 
  - `Description`, which is a short description likely to be shown on the main posts page. 
-  It no longer holds the `CreatedAt` field, which can be inferred from the timestamps on the uploaded version
- Metadata is now populated through an interactive command line process on the `post init` subcommand; this reinforces the desired way of creating posts through `post init` and then `post upload` rather than a manual method 
- `LastChanged` timestamps are updated accordingly when a post is being uploaded via `post upload`

Going forward, these fields are going to be used on the /posts page to show short descriptions under each post, Additionally, they will be used on each individual post to show the author, title, and last changed dates. 
